### PR TITLE
docs: fix markdown typos

### DIFF
--- a/docs/第二章 推荐系统实战/2.2新闻推荐系统实战/docs/2.2.1.1 Mysql基础.md
+++ b/docs/第二章 推荐系统实战/2.2新闻推荐系统实战/docs/2.2.1.1 Mysql基础.md
@@ -418,7 +418,7 @@ MySQL 支持所有标准 SQL 数值数据类型，包括：
 
 + 浮点型数据：`DECIMAL`、`FLOAT`、`REAL` 和 `DOUBLE PRECISION`)。
 
-其中，关键字`INT`是`INTEGER`的同义词，关键字DEC是的同义词。
+其中，关键字`INT`是`INTEGER`的同义词，关键字`DEC`是`DECIMAL`的同义词。
 
 不同关键字的主要区别就是表示的范围或精度不一样。具体如下表：
 
@@ -1129,9 +1129,10 @@ SELECT
 8 rows in set (0.00 sec)
 ```
 
-+ 四则运算所使用的运算符**(+、-、*、/）**称为算术运算符。
+<!-- + 四则运算所使用的运算符**(+、-、*、/)**称为算术运算符。 -->
++ 四则运算所使用的运算符<strong>(+, -, *, /)</strong>称为算术运算符。
 
-+ 在运算表达式中，也可以使用**()**，括号中的运算表达式优先级会得到提升。
++ 在运算表达式中，也可以使用<strong>()<strong>，括号中的运算表达式优先级会得到提升。
 
 + **NULL**的计算结果，仍然还是**NULL**。
 
@@ -1193,7 +1194,7 @@ SELECT
  WHERE NOT sale_price >= 1000;
 ```
 
-2. `AND`运算符合`OR`运算符
+2. `AND`运算符和`OR`运算符
 
 ```mysql
 SELECT product_type, sale_price
@@ -1286,7 +1287,7 @@ SELECT MAX(sale_price) FROM Product;
 1 row in set (0.00 sec)
 ```
 
-**注意点2：**当将字段名作为参数传递给函数时，只会计算不包含`NULL`的行。
+<strong>注意点2：</strong>当将字段名作为参数传递给函数时，只会计算不包含`NULL`的行。
 
 示例：
 
@@ -1340,7 +1341,7 @@ SELECT COUNT(purchase_price) FROM Product;
 
 可以看到结果并不一样，函数忽略了值为**NULL**的行。
 
-`SUM`，`AVG`函数时也一样，计算时会直接忽略，**并不会当做0来处理！**特别注意`AVG`函数，计算时分母也不会算上`NULL`行。
+`SUM`，`AVG`函数时也一样，计算时会直接忽略，<strong>并不会当做0来处理！</strong>特别注意`AVG`函数，计算时分母也不会算上`NULL`行。
 
 **注意点3**：`MAX/MIN`函数几乎适用于所有数据类型的列，包括字符和日期。`SUM/AVG`函数只适用于数值类型的列。
 
@@ -2067,9 +2068,9 @@ cursor = db.cursor(cursor=pymysql.cursors.DictCursor)
 
 更详细的资料，可参考官方的API或者Github:
 
-[pymysql github]: https://github.com/PyMySQL/PyMySQL
+- [pymysql github](https://github.com/PyMySQL/PyMySQL)
 
-[pymysql document]: https://pymysql.readthedocs.io/en/latest/modules/index.html#
+- [pymysql document](https://pymysql.readthedocs.io/en/latest/modules/index.html#)
 
 
 
@@ -2282,7 +2283,7 @@ None
 成功登陆
 ```
 
-​		可以看出，第1组和第2组验证正常，但是第三组出现了异常，输入错误的密码却可以正确登陆。
+​		可以看出，第1组和第2组验证正常，但是第3组出现了异常，输入错误的密码却可以正确登陆。
 
 ​		这是因为在MySQL中`--`的含义是注释，如果通过字符串进行拼接：
 


### PR DESCRIPTION
修复了2.2.1.1章节中MD文档的若干typo，包括加粗失效，链接以及语句😄 @ruyiluo 